### PR TITLE
DT-1585: Remove overlapping classes

### DIFF
--- a/src/button/button.css
+++ b/src/button/button.css
@@ -44,16 +44,7 @@
 
 .primary {
   composes: button;
-  background-color: $theme-color-primary;
-  border-color: darken($theme-color-primary, 0.1);
-  box-shadow: 0px 2px darken($theme-color-primary, 0.1);
   color: white;
-
-  &:hover,
-  &:active {
-    background-color: lighten($theme-color-primary, 0.05);
-    box-shadow: 0px 2px $theme-color-primary;
-  }
 }
 
 .success {

--- a/src/button/theme.js
+++ b/src/button/theme.js
@@ -1,7 +1,11 @@
 import { darken, lighten } from '../utils/colors.js';
 
 export default function(theme) {
-  const { themeColorPrimary } = theme;
+  const newTheme = {
+    themeColorPrimary: '#08a5c5',
+    ...theme
+  };
+  const { themeColorPrimary } = newTheme;
 
   return {
     primary: {


### PR DESCRIPTION
Because CSS classes can't prioritize which class will come first we need to make sure we don't have default colors for anything that can be themed.
