### PR TITLE
TERC-45 add typeahead component

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ramda": "^0.25.0",
     "react-bootstrap": "^0.31.2",
     "react-jss": "2.0.1",
-    "react-select": "^1.0.0-beta8",
+    "react-select": "^1.2.1",
     "react-tether": "^0.5.2",
     "recompose": "^0.25.0",
     "store": "^1.3.20"

--- a/src/button/test.js
+++ b/src/button/test.js
@@ -2,14 +2,16 @@
 import test from 'tape-catch';
 import { shallow } from 'enzyme';
 import React from 'react';
+import cn from 'classnames';
 
 import { Button } from './index.js';
+import styles from './button.css';
 
 test('button', t => {
   const wrapper = shallow(<Button disabled={true}>Hello</Button>);
   t.equal(wrapper.type(), 'button', 'should be a button');
   t.ok(wrapper.props().disabled, 'should be disabled');
-  t.ok(wrapper.hasClass('disabled'), 'should have disabled class');
+  t.ok(wrapper.hasClass(cn(styles['disabled'])), 'should have the disabled styles');
   t.equal(wrapper.text(), 'Hello', 'should render text');
 
   const wrapper2 = shallow(<Button><span>Hello</span><div>Goodbye</div></Button>);

--- a/src/checkbox/card.js
+++ b/src/checkbox/card.js
@@ -4,7 +4,7 @@ import React from 'react';
 import Checkbox from './index';
 import { ThemeProvider } from 'gild';
 
-const devcard = devboard.ns('Checkbox');
+const devcard = devboard.ns('checkbox');
 
 devcard(
   'unchecked',

--- a/src/loading/card.js
+++ b/src/loading/card.js
@@ -3,7 +3,7 @@ import devboard from 'devboard';
 import React from 'react';
 import Loading from './index.js';
 
-const devcard = devboard.ns('Loading');
+const devcard = devboard.ns('loading');
 
 devcard(
   'LOADING',

--- a/src/modal/modal.card.js
+++ b/src/modal/modal.card.js
@@ -5,7 +5,7 @@ import React from 'react';
 import Modal, { Header, Body, Footer } from './index.js';
 import { Button } from '../button';
 
-const devcard = devboard.ns('Modal');
+const devcard = devboard.ns('modal');
 
 devcard(
   'Modal',

--- a/src/tooltip/tooltip.card.js
+++ b/src/tooltip/tooltip.card.js
@@ -4,7 +4,7 @@ import React from 'react';
 
 import Tooltip from './index.js';
 
-const devcard = devboard.ns('Tooltip');
+const devcard = devboard.ns('tooltip');
 
 const el = <div>Content</div>;
 devcard(

--- a/src/typeahead/card.js
+++ b/src/typeahead/card.js
@@ -1,0 +1,98 @@
+import devboard from 'devboard';
+import React from 'react';
+import Select, { Creatable } from './index.js';
+
+const devcard = devboard.ns('typeahead');
+
+devcard(
+  'Single Select with no selected value',
+  <div style={{ width: '200px' }}>
+    <Select
+      value={null}
+      options={[
+        { value: 1, label: 'One' },
+        { value: 2, label: 'Two' },
+        { value: 3, label: 'Three' },
+        { value: 4, label: 'Four' }
+      ]}
+    />
+  </div>
+);
+
+devcard(
+  'Single Select with a selected value',
+  <div style={{ width: '200px' }}>
+    <Select
+      value={1}
+      options={[
+        { value: 1, label: 'One' },
+        { value: 2, label: 'Two' },
+        { value: 3, label: 'Three' },
+        { value: 4, label: 'Four' }
+      ]}
+    />
+  </div>
+);
+
+devcard(
+  'Single Select with creatableentries',
+  <div style={{ width: '200px' }}>
+    <Creatable
+      value={null}
+      options={[
+        { value: 1, label: 'One' },
+        { value: 2, label: 'Two' },
+        { value: 3, label: 'Three' },
+        { value: 4, label: 'Four' }
+      ]}
+    />
+  </div>
+);
+
+devcard(
+  'Multi Select with no selected value',
+  <div style={{ width: '200px' }}>
+    <Select
+      value={[]}
+      multi={true}
+      options={[
+        { value: 1, label: 'One' },
+        { value: 2, label: 'Two' },
+        { value: 3, label: 'Three' },
+        { value: 4, label: 'Four' }
+      ]}
+    />
+  </div>
+);
+
+devcard(
+  'Multi Select with selected values',
+  <div style={{ width: '200px' }}>
+    <Select
+      value={[1,2]}
+      multi={true}
+      options={[
+        { value: 1, label: 'One' },
+        { value: 2, label: 'Two' },
+        { value: 3, label: 'Three' },
+        { value: 4, label: 'Four' }
+      ]}
+    />
+  </div>
+);
+
+devcard(
+  'Multi Select with creatablevalues',
+  <div style={{ width: '200px' }}>
+    <Creatable
+      value={[1,2]}
+      multi={true}
+      options={[
+        { value: 1, label: 'One' },
+        { value: 2, label: 'Two' },
+        { value: 3, label: 'Three' },
+        { value: 4, label: 'Four' }
+      ]}
+    />
+  </div>
+);

--- a/src/typeahead/index.js
+++ b/src/typeahead/index.js
@@ -1,0 +1,27 @@
+import '!!style-loader!css-loader!react-select/dist/react-select.css';
+import Select, {
+  Async as AsyncComponent,
+  Creatable as CreatableComponent,
+  AsyncCreatable as AsyncCreatableComponent
+} from 'react-select';
+import { compose, defaultProps, withProps } from 'recompose';
+import cn from 'classnames';
+import styles from './typeahead.css';
+
+const Styled = compose(
+  defaultProps(() => ({
+    clearable: false,
+    backspaceToRemoveMessage: '',
+    searchPromptText: '',
+    promptTextCreator: () => ''
+  })),
+  withProps(({ className = '', optionClassName = '' }) => ({
+    className: cn(styles['container'], className),
+    optionClassName: cn(styles['option'], optionClassName)
+  }))
+);
+
+export default Styled(Select);
+export const Async = Styled(AsyncComponent);
+export const Creatable = Styled(CreatableComponent);
+export const AsyncCreatable = Styled(AsyncCreatableComponent);

--- a/src/typeahead/typeahead.css
+++ b/src/typeahead/typeahead.css
@@ -1,0 +1,33 @@
+.container {
+  position: relative;
+  min-width: 100px;
+
+  &:global(.Select--multi) {
+    :global {
+      .Select-value {
+        border: none;
+        background-color: #1B83C3;
+      }
+    }
+  }
+
+  :global {
+    .Select-control {
+      border-radius: 3px;
+    }
+
+    .Select-menu-outer {
+      border-radius: 0;
+    }
+
+    .Select-value-icon {
+      padding: 1px 0 3px 5px;
+    }
+
+    .Select-value-label,
+    .Select-clear,
+    .Select-value-icon {
+      color: #fff;
+    }
+  }
+}


### PR DESCRIPTION
TERC-45 typeahead for targeting editor
- add typeahead component by wrapping react-select
- standardize card names to use lowercase for alphabetical sorting
- fix broken test by updating class reference